### PR TITLE
Feature to calculate commas for composite numbers is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For RCN it is necessary to specify an algorithm which maps any prime `p` to its 
 
 The purpose of the `ji-rcn` npm package is to make calculations available related to converting between rational numbers and these notations from RCN.
 
-Currently the API only contains one function, for calculating the prime comma for a specified prime, however the plan is to expand this in future.
+Currently the API contains one function, `getComma`, which calculates the comma for any rational number, and any choice of algorithm.
 
 There is a full test suite using Mocha (`mocha`) for testing and Istanbul (`nyc`) for coverage. Currently all tests pass and coverage is 100%.
 
@@ -26,38 +26,42 @@ There is a full test suite using Mocha (`mocha`) for testing and Istanbul (`nyc`
 - `_.eachFunction` where `_` represents your name for the require, if varying from `ji`
 
 ## API
-- `_.getComma(p, alg)` returns `n/m` (a `Fraction` object from `Fraction.js`) where:
-  - `n/m` is the comma for `p`, calculated using the algorithm `alg`
-  - `alg` is one of `"DR"`, `"SAG"`, `"KG2"`
-  - `alg` defaults to `"DR"` if omitted
-
-Currently the API only contains one function. There are plans to expand this in future.
+- `_.getComma(input, alg)` returns a comma `Fraction` object (from `fraction.js`) using the algorithm `alg`
+  - `alg` is one of `"DR"`, `"SAG"`, `"KG2"` and defaults to `"DR"` if omitted
+  - `input` is parsed by `Fraction` and has many possible valid forms to specify a fraction, see `fraction.js` for more information on this
 
 ## Examples
-- `_.getComma`
-  - `_.getComma(5)` returns `80/81` (a `Fraction` object from `Fraction.js`)
-  - `_.getComma(7)` returns `63/64`
-  - `_.getComma(11)` returns `33/32`
-  - `_.getComma(11, "DR")` returns `33/32`
-  - `_.getComma(11, "SAG")` returns `33/32`
-  - `_.getComma(11, "KG2")` returns `704/729`
-  - `_.getComma(13)` returns `26/27`
-  - `_.getComma(59)` returns `236/243`
-  - `_.getComma(59, "DR")` returns `236/243`
-  - `_.getComma(59, "SAG")` returns `531/512`
-  - `_.getComma(59, "KG2")` returns `236/243`
-  - `_.getComma(139, "DR")` returns `2224/2187`
-  - `_.getComma(139, "SAG")` returns `139/144`
-  - `_.getComma(139, "KG2")` returns `33777/32768`
-  - `_.getComma(59051, "DR")` returns `59051/59049`
-  - `_.getComma(59051, "SAG")` returns `531459/524288`
-  - `_.getComma(59051, "KG2")` returns `531459/524288`
-  - `_.getComma(65537, "DR")` returns `65537/65536`
-  - `_.getComma(65537, "SAG")` returns `65537/65536`
-  - `_.getComma(65537, "KG2")` returns `65537/65536`
-  - `_.getComma(2499949, "DR")` returns `2499949/2519424`
-  - `_.getComma(2499949, "SAG")` returns `67498623/67108864`
-  - `_.getComma(2499949, "KG2")` returns `67498623/67108864`
+
+### For prime inputs
+- `_.getComma(5)` returns `80/81` (a `Fraction` object from `Fraction.js`)
+- `_.getComma(7)` returns `63/64`
+- `_.getComma(11)` returns `33/32`
+- `_.getComma(11, "DR")` returns `33/32`
+- `_.getComma(11, "SAG")` returns `33/32`
+- `_.getComma(11, "KG2")` returns `704/729`
+- `_.getComma(13)` returns `26/27`
+- `_.getComma(59)` returns `236/243`
+- `_.getComma(59, "DR")` returns `236/243`
+- `_.getComma(59, "SAG")` returns `531/512`
+- `_.getComma(59, "KG2")` returns `236/243`
+- `_.getComma(139, "DR")` returns `2224/2187`
+- `_.getComma(139, "SAG")` returns `139/144`
+- `_.getComma(139, "KG2")` returns `33777/32768`
+- `_.getComma(59051, "DR")` returns `59051/59049`
+- `_.getComma(59051, "SAG")` returns `531459/524288`
+- `_.getComma(59051, "KG2")` returns `531459/524288`
+- `_.getComma(65537, "DR")` returns `65537/65536`
+- `_.getComma(65537, "SAG")` returns `65537/65536`
+- `_.getComma(65537, "KG2")` returns `65537/65536`
+- `_.getComma(2499949, "DR")` returns `2499949/2519424`
+- `_.getComma(2499949, "SAG")` returns `67498623/67108864`
+- `_.getComma(2499949, "KG2")` returns `67498623/67108864`
+
+### For composite or Fraction inputs
+- `_.getComma(35)` returns `35/36`
+- `_.getComma(new Fraction(35))` returns `35/36` (uses fraction.js)
+- `_.getComma(7/5)` returns `5103/5120`
+- `_.getComma("1925/247")` returns `61600/60021`
 
 These commas are now available to make beautiful music from. A piece of music written at the prime limit of 2499949 is available [here](https://soundcloud.com/daveryan23/ryan-example-primenumberedblues) (which used the `"DR"` comma given above), and the rest of the author's music is available [here](https://soundcloud.com/daveryan23/tracks).
 

--- a/examples/run.js
+++ b/examples/run.js
@@ -1,14 +1,14 @@
 var Fraction = require('fraction.js')
 // var ji = require('ji-rcn')                     // npm
-var getComma = require('../index.js').getComma    // Locally
+var getCommaP = require('../index.js').getCommaP    // Locally
 
 var p_arr = [5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 5.1, 5.99, 3, 2, 1, 0, -1, -2, 21, 35, 257, 65537, 149, 151, 179, 181, 45077, 59051, 2499949]
 for (var p of p_arr) {
   // Find RCN comma (DR algorithm) for each prime
-  console.log(p + ": " + getComma(p, "DR"))
+  console.log(p + ": " + getCommaP(p, "DR"))
 }
 
-getComma(5,"KG2")
+getCommaP(5,"KG2")
 
 var arr = [
   [5, [80, 81]]
@@ -37,7 +37,7 @@ var arr = [
 ]
 for (var i=0; i<arr.length; i++) {
   var p = arr[i][0]
-  var actualValue = getComma(p, "KG2")
+  var actualValue = getCommaP(p, "KG2")
   var expectedValue = Fraction(arr[i][1])
   console.log("")
   console.log(p)

--- a/functions/calcCents.js
+++ b/functions/calcCents.js
@@ -1,6 +1,5 @@
-// fraction is a Fraction (from fraction.js package)
-
 var calcCents = function(fraction) {
+  // Turn a fraction (from fraction.js package) into a number of cents
 
   var val = Math.abs(fraction.valueOf())
   return 1200 * Math.log(val) / Math.log(2)

--- a/functions/calcExp2.js
+++ b/functions/calcExp2.js
@@ -1,4 +1,6 @@
 var calcExp2 = function(p, exp3) {
+  // For a given prime and power of 3,
+  // find the power of 2 which gets the whole fraction closest to 1/1
 
   var log3 = Math.log(3)
   var log2 = Math.log(2)

--- a/functions/getComma.js
+++ b/functions/getComma.js
@@ -1,14 +1,42 @@
+var Fraction = require('fraction.js')
+var paf = require('primes-and-factors')
+
 var getCommaP = require('./getCommaP')
 
 var getComma = function(input, algType) {
-  // Currently will only work for input = prime
-  // Intending to fix this...
-  // Want input to be:
-  // - a prime p, 7, 1979
-  // - a composite, n, 6, 42
-  // - a fraction, t, "5/7"
-  // ...etc?
-  return getCommaP(input, algType)
+  // Calculate a comma for any rational number (any fraction), and any fraction
+  // Part of the public API
+
+  var fraction = (input instanceof Fraction) ? input : new Fraction(input)
+  // Throws an error for non-numeric string input,
+  // but parses very nicely in other circumstances.
+
+  var numFactors = paf.getFrequency(fraction.n)
+  var denomFactors = paf.getFrequency(fraction.d)
+  // e.g. paf.getFrequency(12) returns [{factor:2,times:2},{factor:3,times:1}]
+
+  var gatherPrimeCommas = function(arrayOfObjs, algType) {
+    // arrayOfObjs is outputted from paf.getFrequency(N)
+    // Each array item is of form {factor:A, times:B}
+    var result = new Fraction(1, 1)
+    for (var i=0; i<arrayOfObjs.length; i++) {
+      var factObj = arrayOfObjs[i]
+      var prime = factObj.factor    // 1 or prime 2, 3, ...
+      var exponent = factObj.times
+      if (prime>1) {
+        var primeComma = getCommaP(prime, algType)
+        var primeCommaPower = primeComma.pow(exponent)
+        result = result.mul(primeCommaPower)
+      }
+    }
+    return result
+  }
+
+  var result = new Fraction(1, 1)
+  result = result.mul(gatherPrimeCommas(numFactors, algType))
+  result = result.div(gatherPrimeCommas(denomFactors, algType))
+
+  return result
 }
 
 module.exports = getComma

--- a/functions/getComma.js
+++ b/functions/getComma.js
@@ -1,0 +1,14 @@
+var getCommaP = require('./getCommaP')
+
+var getComma = function(input, algType) {
+  // Currently will only work for input = prime
+  // Intending to fix this...
+  // Want input to be:
+  // - a prime p, 7, 1979
+  // - a composite, n, 6, 42
+  // - a fraction, t, "5/7"
+  // ...etc?
+  return getCommaP(input, algType)
+}
+
+module.exports = getComma

--- a/functions/getCommaDR.js
+++ b/functions/getCommaDR.js
@@ -1,8 +1,10 @@
 var Fraction = require('fraction.js')
+
 var tripleToFraction = require('./tripleToFraction.js')
 var calcExp2 = require('./calcExp2.js')
 
 var getCommaDR = function(p) {
+  // Calculate a prime comma, according to the DR algorithm
 
   // Some constants
   var cmmin = 1e20                // Unrealisticly high number

--- a/functions/getCommaKG2.js
+++ b/functions/getCommaKG2.js
@@ -2,6 +2,7 @@ var tripleToFraction = require('./tripleToFraction.js')
 var calcExp2 = require('./calcExp2.js')
 
 var getCommaKG2 = function(p) {
+  // Calculate a prime comma, according to the KG2 algorithm
 
   var logp = Math.log(p)
   var log2 = Math.log(2)

--- a/functions/getCommaP.js
+++ b/functions/getCommaP.js
@@ -7,7 +7,7 @@ var defaultResult = function() {
   return new Fraction(1, 1)
 }
 
-var getCommaP = function(p, type) {
+var getCommaP = function(p, algType) {
 
   // p has got to be a number
   if (!(typeof(p)==="number")) {
@@ -31,11 +31,11 @@ var getCommaP = function(p, type) {
 
   // Types include: DR (default), SAG, KG2
   // Also have DK as an alias for SAG
-  var lowerType = (type || "DR").toLowerCase()
+  var lowerAlgType = (algType || "DR").toLowerCase()
 
-  if (lowerType.includes("sag") || lowerType.includes("dk")) {
+  if (lowerAlgType.includes("sag") || lowerAlgType.includes("dk")) {
     return getCommaSAG(p)
-  } else if (lowerType.includes("kg")) {
+  } else if (lowerAlgType.includes("kg")) {
     return getCommaKG2(p)
   } else {
     // Use algorithm DR by default

--- a/functions/getCommaP.js
+++ b/functions/getCommaP.js
@@ -1,13 +1,13 @@
 var Fraction = require('fraction.js')
+
 var getCommaDR = require('./getCommaDR')
 var getCommaSAG = require('./getCommaSAG')
 var getCommaKG2 = require('./getCommaKG2')
 
-var defaultResult = function() {
-  return new Fraction(1, 1)
-}
-
 var getCommaP = function(p, algType) {
+  // Calculate a prime comma, according to the specified algorithm
+
+  var defaultResult = function() {return new Fraction(1, 1)}
 
   // p has got to be a number
   if (!(typeof(p)==="number")) {
@@ -25,11 +25,11 @@ var getCommaP = function(p, algType) {
     return defaultResult()
   }
 
-  // Currently assuming that if p>=5 then its prime
-  // In fact it might not be.
-  // However, the function will succeed if p is prime.
+  // Although non-prime p could potentially be inputted,
+  // this function is private and will only be passed
+  // values in the list 1, 2, 3, 5, 7, 11, 13... (primes continue)
 
-  // Types include: DR (default), SAG, KG2
+  // Algorithm types include: DR (default), SAG, KG2
   // Also have DK as an alias for SAG
   var lowerAlgType = (algType || "DR").toLowerCase()
 

--- a/functions/getCommaP.js
+++ b/functions/getCommaP.js
@@ -7,7 +7,7 @@ var defaultResult = function() {
   return new Fraction(1, 1)
 }
 
-var getComma = function(p, type) {
+var getCommaP = function(p, type) {
 
   // p has got to be a number
   if (!(typeof(p)==="number")) {
@@ -44,4 +44,4 @@ var getComma = function(p, type) {
 
 }
 
-module.exports = getComma
+module.exports = getCommaP

--- a/functions/getCommaSAG.js
+++ b/functions/getCommaSAG.js
@@ -3,6 +3,7 @@ var calcExp2 = require('./calcExp2.js')
 var calcCents = require('./calcCents.js')
 
 var getCommaSAG = function(p) {
+  // Calculate a prime comma, according to the SAG algorithm
 
   var cutoff = 68.5725082211804     // (3^19/2^30)^0.5 in cents
 

--- a/functions/specs/calcCents.spec.js
+++ b/functions/specs/calcCents.spec.js
@@ -1,11 +1,11 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
-var calcCents = require('../calcCents.js')
 
-var tolerance = 1e-3
+var calcCents = require('../calcCents.js')
 
 var fnName = 'calcCents'
 describe(fnName, function() {
+  var tolerance = 1e-3
 
   var runTest = function(fractionArray, cents) {
     var fraction = new Fraction(fractionArray)

--- a/functions/specs/calcExp2.spec.js
+++ b/functions/specs/calcExp2.spec.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+
 var calcExp2 = require('../calcExp2.js')
 var tripleToFraction = require('../tripleToFraction.js')
 

--- a/functions/specs/getComma.spec.js
+++ b/functions/specs/getComma.spec.js
@@ -1,38 +1,39 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
-var getCommaP = require('../getCommaP.js')
+var getComma = require('../getComma.js')
 
 var defaultFractionArray = [1, 1]
 
-var fnName = 'getCommaP'
+var fnName = 'getComma'
 describe(fnName, function() {
 
-  var runTest = function(prime, fractionArray, algType) {
-    var actualResult = getCommaP(prime, algType)
+  var runTest = function(input, fractionArray, algType) {
+    var actualResult = getComma(input, algType)
     var expectedResult = new Fraction(fractionArray)
     var typeText = ""
     if (algType) {
       typeText = ", " + algType
     }
-    var label = fnName + "(" + prime + typeText + ") returns " + expectedResult.toFraction()
+    var label = fnName + "(" + input + typeText + ") returns " + expectedResult.toFraction()
     it(label, function() {
       assert.deepStrictEqual(actualResult, expectedResult)
     })
   }
 
   var testArray = [
-    ["string", defaultFractionArray]
-  , [null, defaultFractionArray]
-  , [true, defaultFractionArray]
-  , [Infinity, defaultFractionArray]
-  , [1e16, defaultFractionArray]
+    [1, defaultFractionArray]
+  , [2, defaultFractionArray]
   , [3, defaultFractionArray]
-  , [-1, defaultFractionArray]
-  , [-2003, defaultFractionArray]
+  , [5, [80, 81]]
+  , [7, [63, 64]]
+  , [35, [35, 36]]
+  , [143, [143, 144]]
+  //, [169, [676, 729]]        // Require algorithm for composites
+  //, [2197, [17576, 19683]]   // Require algorithm for composites
   , [139, [2224, 2187]]         // Default algorithm is DR
   , [139, [2224, 2187], "DR"]
   , [139, [139, 144], "SAG"]
-  , [139, [139, 144], "DK"]     // Added an alias DK (Dave Keenan) for SAG
+  , [139, [139, 144], "DK"]
   , [139, [33777, 32768], "KG2"]
   ]
 

--- a/functions/specs/getComma.spec.js
+++ b/functions/specs/getComma.spec.js
@@ -1,44 +1,61 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
-var getComma = require('../getComma.js')
 
-var defaultFractionArray = [1, 1]
+var getComma = require('../getComma.js')
 
 var fnName = 'getComma'
 describe(fnName, function() {
 
-  var runTest = function(input, fractionArray, algType) {
+  var runTest = function(input, fractionArray, algType, comment) {
     var actualResult = getComma(input, algType)
     var expectedResult = new Fraction(fractionArray)
-    var typeText = ""
-    if (algType) {
-      typeText = ", " + algType
-    }
-    var label = fnName + "(" + input + typeText + ") returns " + expectedResult.toFraction()
+    var typeText = (algType) ? ", " + algType : ""
+    var commentText = (comment) ? "   (" + comment + ")" : ""
+    var label = fnName + "(" + input + typeText + ") returns " + expectedResult.toFraction() + commentText
     it(label, function() {
       assert.deepStrictEqual(actualResult, expectedResult)
     })
   }
 
   var testArray = [
-    [1, defaultFractionArray]
-  , [2, defaultFractionArray]
-  , [3, defaultFractionArray]
+    [1, [1, 1]]
+  , [2, [1, 1]]
+  , [3, [1, 1]]
   , [5, [80, 81]]
+  , [new Fraction(5), [80, 81]]
   , [7, [63, 64]]
-  , [35, [35, 36]]
-  , [143, [143, 144]]
-  //, [169, [676, 729]]        // Require algorithm for composites
-  //, [2197, [17576, 19683]]   // Require algorithm for composites
-  , [139, [2224, 2187]]         // Default algorithm is DR
+  , [35, [35, 36],,"from 5*7"]
+  , [125, [80*80*80, 81*81*81],,"from 5^3"]
+  , [143, [143, 144],,"from 11*13"]
+  , [169, [676, 729],,"from 13*13"]
+  , [139, [2224, 2187],,"default algorithm is DR"]
   , [139, [2224, 2187], "DR"]
   , [139, [139, 144], "SAG"]
   , [139, [139, 144], "DK"]
   , [139, [33777, 32768], "KG2"]
+  , [2197, [17576, 19683],,"from 13*13*13"]
+  , [2310, [80*63*33, 81*64*32],,"from 2*3*5*7*11"]
+  , ["1/1", [1, 1]]
+  , ["1/2", [1, 1]]
+  , ["2/1", [1, 1]]
+  , ["5/1", [80, 81]]
+  , ["1/7", [64, 63]]
+  , ["7/5", [5103, 5120]]
+  , [new Fraction("7/5"), [5103, 5120],,"uses Fraction('7/5')"]
+  , [new Fraction(7, 5), [5103, 5120],,"uses Fraction(7, 5)"]
+  , [new Fraction([7, 5]), [5103, 5120],,"uses Fraction([7, 5]])"]
+  , ["1925/247", [61600, 60021],,"from 5*5*7*11 / (13*19)"]
+  , [[5*13,7*11], [80*26*64*32, 81*27*63*33],,"from 5*13/(7*11)"]
+  , [[5*11,7*13], [80*27*64*33, 81*26*63*32],,"from 5*11/(7*13)"]
+  , [45077, [135231, 131072]]
+  , [59051, [59051, 59049]]
+  , [65537, [65537, 65536]]
+  , [2499949, [2499949, 2519424]]
+  , ["2499949/65537", [2499949*65536, 2519424*65537]]
   ]
 
   for (var i=0; i<testArray.length; i++) {
-    runTest(testArray[i][0], testArray[i][1], testArray[i][2])
+    runTest(testArray[i][0], testArray[i][1], testArray[i][2], testArray[i][3])
   }
 
 })

--- a/functions/specs/getCommaDR.spec.js
+++ b/functions/specs/getCommaDR.spec.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
+
 var getCommaDR = require('../getCommaDR.js')
 
 var fnName = 'getCommaDR'
@@ -17,7 +18,10 @@ describe(fnName, function() {
   // Lots of tests (DR algorithm)
   // Many of these inputs are listed in the online paper
   var testArray = [
-    [5, [80, 81]]
+    [1, [1, 1]]
+  , [2, [1, 1]]
+  , [3, [1, 1]]
+  , [5, [80, 81]]
   , [7, [63, 64]]
   , [11, [33, 32]]
   , [13, [26, 27]]

--- a/functions/specs/getCommaKG2.spec.js
+++ b/functions/specs/getCommaKG2.spec.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
+
 var getCommaKG2 = require('../getCommaKG2.js')
 
 var fnName = 'getCommaKG2'
@@ -17,7 +18,10 @@ describe(fnName, function() {
   // Lots of tests (KG2 algorithm)
   // Many of these inputs are listed in the online paper
   var testArray = [
-    [5, [80, 81]]
+    [1, [1, 1]]
+  , [2, [1, 1]]
+  , [3, [1, 1]]
+  , [5, [80, 81]]
   , [7, [63, 64]]
   , [11, [704, 729]]
   , [13, [1053, 1024]]

--- a/functions/specs/getCommaP.spec.js
+++ b/functions/specs/getCommaP.spec.js
@@ -1,14 +1,14 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
-var getComma = require('../getComma.js')
+var getCommaP = require('../getCommaP.js')
 
 var defaultFractionArray = [1, 1]
 
-var fnName = 'getComma'
+var fnName = 'getCommaP'
 describe(fnName, function() {
 
   var runTest = function(prime, fractionArray, type) {
-    var actualResult = getComma(prime, type)
+    var actualResult = getCommaP(prime, type)
     var expectedResult = new Fraction(fractionArray)
     var typeText = ""
     if (type) {

--- a/functions/specs/getCommaP.spec.js
+++ b/functions/specs/getCommaP.spec.js
@@ -1,11 +1,11 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
-var getCommaP = require('../getCommaP.js')
 
-var defaultFractionArray = [1, 1]
+var getCommaP = require('../getCommaP.js')
 
 var fnName = 'getCommaP'
 describe(fnName, function() {
+  var defaultFractionArray = [1, 1]
 
   var runTest = function(prime, fractionArray, algType) {
     var actualResult = getCommaP(prime, algType)

--- a/functions/specs/getCommaSAG.spec.js
+++ b/functions/specs/getCommaSAG.spec.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
+
 var getCommaSAG = require('../getCommaSAG.js')
 
 var fnName = 'getCommaSAG'
@@ -17,7 +18,10 @@ describe(fnName, function() {
   // Lots of tests (SAG algorithm)
   // Many of these inputs are listed in the online paper
   var testArray = [
-    [5, [80, 81]]
+    [1, [1, 1]]
+  , [2, [1, 1]]
+  , [3, [1, 1]]
+  , [5, [80, 81]]
   , [7, [63, 64]]
   , [11, [33, 32]]
   , [13, [26, 27]]

--- a/functions/specs/tripleToFraction.spec.js
+++ b/functions/specs/tripleToFraction.spec.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var Fraction = require('fraction.js')
+
 var tripleToFraction = require('../tripleToFraction.js')
 
 var fnName = 'tripleToFraction'

--- a/functions/tripleToFraction.js
+++ b/functions/tripleToFraction.js
@@ -1,9 +1,14 @@
 var Fraction = require('fraction.js')
 
 var tripleToFraction = function(p, a, b) {
+
+  // The triple is a prime, a power of 2, and a power of 3
+  // Output a Fraction as per fraction.js package
+
   var num = p * Math.pow(2, Math.max(0, a)) * Math.pow(3, Math.max(0, b))
   var denom = Math.pow(2, Math.max(0, -a)) * Math.pow(3, Math.max(0, -b))
   return new Fraction(num, denom)
+  
 }
 
 module.exports = tripleToFraction

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  getComma: require('./functions/getComma')
+  getCommaP: require('./functions/getCommaP')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ji-rcn",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2448,6 +2448,11 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "primes-and-factors": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/primes-and-factors/-/primes-and-factors-0.1.4.tgz",
+      "integrity": "sha1-McPTFC3I5AMMjCB1vMgZcdUMRCU="
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ji-rcn",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Functions for converting between numbers and notations",
   "author": "David Ryan",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "examples": "cd ./examples && node run.js"
   },
   "dependencies": {
-    "fraction.js": "^4.0.8"
+    "fraction.js": "^4.0.8",
+    "primes-and-factors": "^0.1.4"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
For a fraction, only the prime information for 5 and above is used.

E.g., comma for 14/15 is same as comma for 7/5, which will be (63/64) / (80/81) = 5103/5120

This is now implemented, please merge in.